### PR TITLE
Changed the default settings path on all platforms

### DIFF
--- a/progtool/settings.py
+++ b/progtool/settings.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Annotated, Optional
 import yaml
 import pydantic
+import platform
+import os
 
 from progtool.repository import InvalidIdentifierFile, MissingIdentifierFile, check_repository_identifier
 
@@ -23,7 +25,11 @@ _settings: Optional[Settings]
 
 
 def default_storage_path() -> Path:
-    return (Path.home() / 'progtool').absolute()
+    baseDir = Path.home()
+    if platform.system() == 'Windows':
+        baseDir = Path(os.getenv('APPDATA')) # type: ignore
+        
+    return (baseDir / '.progtool').absolute()
 
 
 def default_settings_path() -> Path:


### PR DESCRIPTION
The settings path now defaults to the `AppData/Roaming` folder of the user on Windows.
It defaults to `$HOME/.progtool` on other systems, it is now a hidden folder on Unix-like systems.